### PR TITLE
Serviceworker implementation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@
 1. Open Chrome
 2. Browse a website using ShimmerCat
 3. Click the extension icon in the top right corner
+
+## Setting chunked image response compensation value
+For images received from server in a chunked procedure, most of the filesize can be computed via simply counting the chunks, however some is lost due to missing padding and header structure. 
+To change the value used to compensate for this missing data, change the constant value, CHUNKED_IMAGE_LOSS_COMPENSATION_PERCENT that is found in /content-js/state.js

--- a/content-js/state.js
+++ b/content-js/state.js
@@ -109,6 +109,8 @@ function serviceWorkerDisplay() {
         let h = highlightAsWebp.bind(null, im);
         let g = highlightAsProcessing.bind(null, im);
         let i = highlightAsNonViable.bind(null, im);
+
+        let b = highlightAsServiceWorkerImage.bind(null, im);
         let optimised_image_url = getServiceWorkerUrl(url);
 
         // if domain isn't in serviceWorker domains definition or url is mangled, skip image
@@ -131,6 +133,11 @@ function serviceWorkerDisplay() {
                 // console.log("status: ", status);
                 // console.log("transfer_size: ", transfer_size);
                 removeCustomStyles(im);
+                // if serviceWorker processed then we colour it blue for now
+                if(serviceWorker){
+                    im.classList.remove("scbca-gray"); 
+                    b()
+                }else{
                 if (status === "ready") {
                     im.classList.remove("scbca-gray");
                     h();
@@ -143,6 +150,7 @@ function serviceWorkerDisplay() {
                 } else {
                     im.classList.add("scbca-gray");
                 }    
+            }
                 if (transfer_size !== null) {
                     // Active = true;
                     optimizedSizeModel[optimised_image_url] = {
@@ -150,7 +158,8 @@ function serviceWorkerDisplay() {
                         'transfer_size': transfer_size
                     }
                 }
-            });
+                
+        });
     } 
     // console.log("optimised: ",optimizedSizeModel);
     // console.log("unoptimised: ", unoptimizedSizeModel);
@@ -284,7 +293,10 @@ function highlightAsNonViable(im_element) {
     im_element.classList.add("scbca-non-viable");
 }
 
-
+function highlightAsServiceWorkerImage(im_element){
+    im_element.classList.add("scbca-serviceworker");
+ 
+}
 function removeCustomStyles(im_element) {
     const tokens = [
         "scbca-gray",

--- a/content-js/state.js
+++ b/content-js/state.js
@@ -9,7 +9,7 @@ function* iterateOnImages() {
     for (let im of images) {
         if (canUseUrl(im.currentSrc)) {
             let url = new URL(im.currentSrc);
-            //console.log(` This is the url ${url}`);
+            // console.log(` This is the url ${url}`);
             let doc_hostname = document.location.hostname;
             if (url.hostname === doc_hostname) {
                 yield [im, url];
@@ -17,9 +17,9 @@ function* iterateOnImages() {
         }
         if (retrieving(im.style['backgroundImage'])) {
             let returned_url = retrieving(im.style['backgroundImage']);
-            console.log(`this is from reteriving${returned_url}`)
+            // console.log(`this is from reteriving${returned_url}`)
             let url = new URL(returned_url);
-            console.log(`this is from donwnside ${url}`)
+            // console.log(`this is from donwnside ${url}`)
             let doc_hostname = document.location.hostname;
             if (url.hostname === doc_hostname) {
                 yield [im, url];
@@ -27,6 +27,29 @@ function* iterateOnImages() {
         }
     }
 }
+
+// function* iterateOnServiceWorkerImages() {
+//     let images = document.querySelectorAll('*,img.lazyloaded');
+//     for (let im of images) {
+//         if (canUseUrl(im.currentSrc)) {
+//             let url = new URL(im.currentSrc);
+//             let doc_hostname = document.location.hostname;
+//             if (url.hostname === doc_hostname) {
+//                 yield [im, url];
+//             }
+//         }
+//         if (retrieving(im.style['backgroundImage'])) {
+//             let returned_url = retrieving(im.style['backgroundImage']);
+//             // console.log(`this is from reteriving${returned_url}`)
+//             let url = new URL(returned_url);
+//             // console.log(`this is from donwnside ${url}`)
+//             let doc_hostname = document.location.hostname;
+//             if (url.hostname === doc_hostname) {
+//                 yield [im, url];
+//             }
+//         }
+//     }
+// }
 
 
 
@@ -72,34 +95,90 @@ function displaySelected() {
     }
 }
 
+function serviceWorkerDisplay() {
+    optimizedSizeModel = {};
+    unoptimizedSizeModel = {};
+    for (let [im, url] of iterateOnImages()) {
+        let h = highlightAsWebp.bind(null, im);
+        let g = highlightAsProcessing.bind(null, im);
+        let i = highlightAsNonViable.bind(null, im);
+
+        let use_url_for_highlight = originalURLOfImage(im);
+        // original image on domain isn't using haps by default so we do not need this
+        // let use_url = toNoHAPsURL(use_url_for_highlight);
+        populateUnoptimizedSizeModel(use_url_for_highlight);
+
+        let optimised_image_url = optimisedURLofImage(im);
+
+        im.currentSrc = use_url_for_highlight;
+        im.src = use_url_for_highlight;
+
+        // urlPointsToStatus(use_url_for_highlight)
+        //     .then(([status, transfer_size]) => {
+        //         removeCustomStyles(im);
+        //         if (status === "ready") {
+        //             im.classList.remove("scbca-gray");
+        //             h();
+        //         } else if (status === "non-viable") {
+        //             im.classList.remove("scbca-gray");
+        //             i();
+        //         } else if (status === "in-processing") {
+        //             im.classList.remove("scbca-gray");
+        //             g();
+        //         } else {
+        //             im.classList.add("scbca-gray");
+        //         }
+        //         if (transfer_size !== null) {
+        //             optimizedSizeModel[use_url_for_highlight] = {
+        //                 'status': status,
+        //                 'transfer_size': transfer_size
+        //             }
+        //         }
+        //     });
+    } 
+}
+
+function optimisedURLofImage(im){
+    // make get request to cloud domain
+
+}
 
 function refreshSelectedView() {
     if (currentView === "selected") {
+        if (CheckWorkerProcess()){
+            serviceWorkerDisplay();        
+        }else{
         displaySelected();
-        window.setTimeout(refreshSelectedView, 15000);
-        window.setTimeout(sendModelSummaries, 3000);
+        }
+        // window.setTimeout(refreshSelectedView, 15000);
+        // window.setTimeout(sendModelSummaries, 3000);
     }
 }
 
 
 function changeToSelected() {
     if (currentView !== "selected") {
-        window.setTimeout(sendModelSummaries, 3000);
-        window.setTimeout(refreshSelectedView, 15000);
+        // window.setTimeout(sendModelSummaries, 3000);
+        // window.setTimeout(refreshSelectedView, 15000);
     }
     currentView = "selected";
+    if (CheckWorkerProcess()){
+        serviceWorkerDisplay();        
+    }else{
     displaySelected();
+    }
 }
 
 
 function sendModelSummaries() {
-    CheckWorkerProcess();
+    // CheckWorkerProcess();
+    // serviceWorker = CheckWorkerProcess();
     browser.runtime.sendMessage({
         'kind': 'model-summary',
         'unoptimized': unoptimizedSizeModel,
         'optimized': optimizedSizeModel,
         'active': Active,
-        'serviceWorker': serviceWorker
+        'serviceWorker': serviceWorker,
     }).then(
         () => { },
         () => { },
@@ -175,9 +254,9 @@ function retrieving(url) {
 
     }
     else {
-        console.log(url)
-        console.log(`Before placing ${typeof (url)}`)
-        console.log(`The length = ${url.length}`)
+        // console.log(url)
+        // console.log(`Before placing ${typeof (url)}`)
+        // console.log(`The length = ${url.length}`)
         url = "https://" + document.location.hostname + url.replace(/^url\(['"](.+)['"]\)/, '$1');
         // PARAMETER FOR IMAGES SELECTION
         var dotIndex = url.lastIndexOf('.');
@@ -188,18 +267,18 @@ function retrieving(url) {
         let images_extensions = ['.png', '.jpg']
         if (images_extensions.includes(ext)) {
 
-            console.log(`from retriving funciton ${url}`)
+            // console.log(`from retriving funciton ${url}`)
 
             return url;
         }
         else if (/.jpg\?preset|.png\?preset|.gif\?preset/.test(url)) {
-            console.log("Checked via jpg")
-            console.log(url)
+            // console.log("Checked via jpg")
+            // console.log(url)
             return url;
         }
         else {
-            console.log("The issue is ")
-            console.log(url)
+            // console.log("The issue is ")
+            // console.log(url)
         }
 
     }
@@ -258,13 +337,13 @@ function
 
     image_opt_status_from_headers(response) {
     let headers_status = null;
-
+    // console.log(response);
     for (let
         /** @type String[] */
         header_val_arr of response.headers.entries()) {
         let [header_name, header_value] = header_val_arr;
         //console.log(`The header value ${header_name} and ${header_value}`)
-        console.log(header_val_arr);
+        // console.log(header_val_arr);
 
         if (header_name === "sc-note") {
             Active = true;
@@ -279,7 +358,7 @@ function
                 break;
             }
             else {
-                console.log('Open the value')
+                // console.log('Open the value')
             }
         }
 
@@ -332,11 +411,11 @@ function urlPointsToStatus(url) {
         prom.then(
             (response) => {
                 if (response.status === 200) {
-                    console.log("This is the response of header")
-                    console.log(response.headers);
+                    // console.log("This is the response of header")
+                    // console.log(response.headers);
                     let headers_status = image_opt_status_from_headers(response);
                     let indicated_size = size_from_headers(response);
-                    console.log(`The header status ${headers_status} and ${indicated_size}`)
+                    // console.log(`The header status ${headers_status} and ${indicated_size}`)
                     //optimizedSizeModel[captured_url] = indicated_size;
                     //noinspection JSIncompatibleTypesComparison;
                     if (headers_status === null) {
@@ -380,8 +459,8 @@ function populateUnoptimizedSizeModel(url) {
     prom.then(
         (response) => {
             if (response.status === 200) {
-                console.log("For unptomized")
-                console.log(response.headers);
+                // console.log("For unptomized")
+                // console.log(response.headers);
                 let indicated_size = size_from_headers(response);
                 unoptimizedSizeModel[url] = indicated_size;
 
@@ -402,6 +481,7 @@ function toNoHAPsURL(original_url) {
 
 function originalURLOfImage(im) {
     let dataset = im.dataset;
+    // console.log(dataset);
     if (dataset.hasOwnProperty("scbOriginalLocation")) {
     }
     else if (im.currentSrc) {
@@ -456,7 +536,7 @@ browser.runtime.onMessage.addListener(
         } else if (request.hasOwnProperty("refreshView") && shimSelected === "select") {
             // Do this once more ? .. this is not the most efficient
             // way to do stuff, but ...
-            console.log("refreshView");
+            // console.log("refreshView");
             changeToSelected();
         }
 
@@ -469,9 +549,40 @@ CheckWorkerProcess = function () {
         if (scripts[i].src) {
             if (scripts[i].src.includes("sc-sw-installer")) {
                 serviceWorker = true;
-                break;
+                let origin = window.location.origin;
+                //get sc script
+                let fetch_sc_script = new Request(
+                    origin + "/sc-sw.min.js",
+                    {
+                        "method": "GET",
+                    });
+                    
+                
+                fetch(fetch_sc_script).then(function(res){
+                    return res.text()
+                }).then(function(data){
+                    //parse cloud domain
+
+                    // create substring of switch_domain_for_images object
+                    var start = data.search("switch_domains_for_images") + 27;
+                    var end =data.search("shimmercat.cloud") + 18; 
+
+                    // parse as JSON (JSON.parse(string)) and return object so we can iterate over it
+                    // create substring
+                    var substring = data.substring(start, end);
+                    console.log(substring);
+                    var newStart = substring.search(':') + 3;
+                    var newEnd = substring.search('}') - 1;
+                    var domain = substring.substring(newStart, newEnd);
+                    console.log(domain);
+                    // var n = data.search("shimmercat");
+                    // console.log(n);
+                })
+                return true;
             }
         }
     }
+    serviceWorker = false;
+    return false;
 
 }

--- a/content-js/state.js
+++ b/content-js/state.js
@@ -94,8 +94,9 @@ function displaySelected() {
                 if (transfer_size !== null) {
                     optimizedSizeModel[use_url_for_highlight] = {
                         'status': status,
-                        'transfer_size': transfer_size
-                    }
+                        'transfer_size': transfer_size,
+                        'pathname': url.pathname + url.search
+                    };
                 }
             });
     }
@@ -155,12 +156,13 @@ function serviceWorkerDisplay() {
                     // Active = true;
                     optimizedSizeModel[optimised_image_url] = {
                         'status': status,
-                        'transfer_size': transfer_size
+                        'transfer_size': transfer_size,
+                        'pathname': url.pathname + url.search};
                     }
                 }
                 
-        });
-    } 
+        );
+    }
     // console.log("optimised: ",optimizedSizeModel);
     // console.log("unoptimised: ", unoptimizedSizeModel);
 }
@@ -547,6 +549,7 @@ function urlPointsToStatus(url) {
 }
 
 function populateUnoptimizedSizeModel(url) {
+    let urlObj = new URL(url)
     let mode = "same-origin";
     let headers = new Headers({
         "cache-control": "no-cache",
@@ -580,14 +583,16 @@ function populateUnoptimizedSizeModel(url) {
                     // need to check and potentially refactor this
                     let indicated_size = await processChunkedResponse(response).then(onChunkedResponseComplete).catch(onChunkedResponseError);
                     console.log("indicated size (chunked)", indicated_size)
-                    unoptimizedSizeModel[url] = indicated_size;
+                    unoptimizedSizeModel[url] = {"transfer_size": indicated_size, "pathname": urlObj.pathname + urlObj.search}
                 }else{
                     // for (var pair of response.headers.entries()) {
                     //     console.log(pair[0]+ ': '+ pair[1]);
                     // }
+                    
+                    // Active = true;
                     let indicated_size = size_from_headers(response);
                     console.log("indicated size (non-chunked)", indicated_size)
-                    unoptimizedSizeModel[url] = indicated_size;
+                    unoptimizedSizeModel[url] = {"transfer_size": indicated_size, "pathname": urlObj.pathname + stripHAPsSearchParam(urlObj.search)}
                 }
             } else {
                 console.log(response);
@@ -599,6 +604,10 @@ function populateUnoptimizedSizeModel(url) {
     );
 
     
+}
+
+function stripHAPsSearchParam(url){
+    return url.replace('?sc-disable-haps=1', '');
 }
 
 function toNoHAPsURL(original_url) {

--- a/css/content_special.css
+++ b/css/content_special.css
@@ -102,3 +102,8 @@
 .scbca-non-viable:not(.scbca-good):not(.scbca-bad) {
   filter: invert();
 }
+
+.scbca-serviceworker:not(.scbca-good):not(.scbca-bad){
+  filter: sepia(100%) hue-rotate(190deg) saturate(500%);
+  outline: solid #0066CC 4px;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,7 +1,7 @@
 body {
     background-color: white;
     width: 350px;
-    min-height: 580px !important;
+    min-height: 600px !important;
     font-family: sans-serif;
     margin: 0;
     color: black;
@@ -209,7 +209,7 @@ h1 {
 .text-ul-li {
     font-size: 12px;
     position: relative;
-    top: 90%;
+    top: 70%;
     left: 60px;
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,11 +1,15 @@
 body {
     background-color: white;
     width: 350px;
-    height: 550px !important;
+    min-height: 580px !important;
     font-family: sans-serif;
     margin: 0;
     color: black;
     font-size: 14px;
+}
+
+#app-root{
+    margin-bottom: 15%;
 }
 
 .Message {
@@ -170,6 +174,7 @@ h1 {
     background: darkslategrey;
     position: relative;
     top: 5px;
+    margin-bottom: 20px;
 }
 
 .btn:hover {
@@ -279,7 +284,19 @@ ul li::before {
 .ImagesCount{
     text-align: center;
     margin-top: 31%;
+    left: 60px
+}
+
+.filetypes-count-div{
+    text-align: center;
+    margin-top: 2%;
+    left: 60px;
 }
 .btn-top {
     top: 20px;
+    margin-bottom: 20px;
+}
+
+.bold{
+    font-weight: 600;
 }

--- a/js/download.js
+++ b/js/download.js
@@ -2,11 +2,10 @@
 download_csv();
 
 
-
+// function that downloads csv for each image found on document with the optimised size and original size for comparing sizes 
 function download_csv(){
 	var s = localStorage.getItem("clog");
 	data =  JSON.parse(s);
-	console.log(data);
 	var a = [];
 	var b = [];
 	var c = [];
@@ -18,32 +17,23 @@ function download_csv(){
 			a.push(key);
 		}
 	}
-	// console.log(a);
 	// populate array with unoptimised transfer sizes
 	for (var key in data.unoptimized) {
 		if (data.unoptimized.hasOwnProperty(key)) {
 			b.push(data.unoptimized[key]["transfer_size"]);
 
-			console.log("key: ",key);
 			var optimizedKey = Object.keys(data.optimized).find(searchKey => data.optimized[searchKey]["pathname"] === data.unoptimized[key]["pathname"]);
-			console.log("optimizedKey", optimizedKey);	
 			c.push(data.optimized[optimizedKey]["transfer_size"])
 		}
 	} 
-	// console.log(b);
-	// populate array with optimised transfer sizes
-	// for (var key in data.optimized) {	
-	// 	if (data.optimized.hasOwnProperty(key)) {
-	// 		c.push(data.optimized[key]["transfer_size"]);
-	// 	}	
-	// }
+
+	// create combined array for storing in csv
 	var combined = [];
 	for(var i=0; i < a.length; i++){
-		// console.log('FROM DOWNLOAD JS ')
-		// console.log({img:a[i],realsize:b[i],optimizedSize:c[i]})
 		combined.push({img:a[i],realsize:b[i],optimizedSize:c[i]});
 	}
 	
+	// build csv file
 	var csv = 'Image, Original Size, Optimized Size\n';
 	combined.forEach(function(col) {
 	cimg = col.img.replace('?sc-disable-haps=1','');
@@ -51,6 +41,7 @@ function download_csv(){
 	csv += "\n";
 
 	}); 
+	// file metatags
 	var filename = Date.now();
 	var hiddenElement = document.createElement('a');
     hiddenElement.href = 'data:text/csv;charset=utf-8,' + encodeURI(csv);

--- a/js/download.js
+++ b/js/download.js
@@ -1,3 +1,4 @@
+
 download_csv();
 
 
@@ -5,44 +6,41 @@ download_csv();
 function download_csv(){
 	var s = localStorage.getItem("clog");
 	data =  JSON.parse(s);
+	console.log(data);
 	var a = [];
 	var b = [];
 	var c = [];
 	var combined = [];
 
+	// populate array with unoptimised img urls
 	for (var key in data.unoptimized) {
 		if (data.unoptimized.hasOwnProperty(key)) {
 			a.push(key);
 		}
 	}
+	// console.log(a);
+	// populate array with unoptimised transfer sizes
 	for (var key in data.unoptimized) {
 		if (data.unoptimized.hasOwnProperty(key)) {
-			b.push(data.unoptimized[key]);
-		}
-		
-	} 
-	for (var key in data.optimized) {	
-		if (data.optimized.hasOwnProperty(key)) {
-			var optimizedKey = data.optimized[key];
-			console.log("From optimized key")
-			console.log(optimizedKey)
-			for (var key1 in optimizedKey) {
-				console.log("This is the log")
-				console.log(key1)
-				if (optimizedKey.hasOwnProperty(key1)) {
-					//if(optimizedKey[key1]!="non-viable"){
-						if (key1 =='transfer_size'){
-						c.push(optimizedKey[key1]);
-						}
-					}
-				}
-			}
-		}	
+			b.push(data.unoptimized[key]["transfer_size"]);
 
+			console.log("key: ",key);
+			var optimizedKey = Object.keys(data.optimized).find(searchKey => data.optimized[searchKey]["pathname"] === data.unoptimized[key]["pathname"]);
+			console.log("optimizedKey", optimizedKey);	
+			c.push(data.optimized[optimizedKey]["transfer_size"])
+		}
+	} 
+	// console.log(b);
+	// populate array with optimised transfer sizes
+	// for (var key in data.optimized) {	
+	// 	if (data.optimized.hasOwnProperty(key)) {
+	// 		c.push(data.optimized[key]["transfer_size"]);
+	// 	}	
+	// }
 	var combined = [];
 	for(var i=0; i < a.length; i++){
-		console.log('FROM DOWNLOAD JS ')
-		console.log({img:a[i],realsize:b[i],optimizedSize:c[i]})
+		// console.log('FROM DOWNLOAD JS ')
+		// console.log({img:a[i],realsize:b[i],optimizedSize:c[i]})
 		combined.push({img:a[i],realsize:b[i],optimizedSize:c[i]});
 	}
 	

--- a/js/popup.js
+++ b/js/popup.js
@@ -10,7 +10,8 @@ let vue_data = {
     "ServiceWorker": false,
     "SplashScreen": true,
     "Spinner": false,
-    "imagesCount":0
+    "imagesCount":0,
+    "filetypes": {}
 };
 
 
@@ -89,7 +90,36 @@ function summarizeImagesModel(images_summary_input) {
 
     vue_data["total_size_optimized"] = numberWithSpaces(formatBytes(total_optimized_size));
     vue_data["total_size_unoptimized"] = numberWithSpaces(formatBytes(total_unoptimized_size));
-    vue_data["image_compression"] = imageCompression(total_optimized_size, total_unoptimized_size) + '%';
+    let compression = imageCompression(total_optimized_size, total_unoptimized_size);
+    if (compression >= 0){
+        vue_data["image_compression"] = compression + "%";
+    }else{
+        vue_data["image_compression"] = "0%"; 
+    }
+
+    // calculate filetype percentages
+    let total_files = Object.keys(images_summary_input.optimized).length;
+    console.log(total_files);
+    let filetypes = {};
+    // get file totals
+    console.log(Object.keys(images_summary_input.optimized));
+    for (const file of Object.keys(images_summary_input.optimized)){
+        let filetype = images_summary_input.optimized[file]["filetype"]
+        console.log(filetype);
+        if(!(filetype in filetypes)){
+            filetypes[filetype] = 1;
+        }else{
+            filetypes[filetype] += 1;     
+        }
+    }
+    console.log("fieltypes 1: ",filetypes)
+    for (const filetype of Object.keys(filetypes)){
+        filetypes[filetype] = Math.round((filetypes[filetype] / total_files) * 100) + "%";
+    }
+    console.log("fieltypes 2: ",filetypes)
+
+    vue_data["filetypes"] = filetypes;
+    
     console.log("total optimised: ", vue_data["total_size_optimized"]);
     console.log("total unoptimised: ", vue_data["total_size_unoptimized"]);
     console.log("compression: ", vue_data["image_compression"]);

--- a/js/popup.js
+++ b/js/popup.js
@@ -42,6 +42,7 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         // console.log("Message from active tab");
         localStorage.setItem('clog', JSON.stringify(request));
         if (request.active === false) {
+            console.log("true");
             vue_data["Active"] = false;
         }
         vue_data["imagesCount"]=Object.keys(request.optimized).length;
@@ -89,6 +90,9 @@ function summarizeImagesModel(images_summary_input) {
     vue_data["total_size_optimized"] = numberWithSpaces(formatBytes(total_optimized_size));
     vue_data["total_size_unoptimized"] = numberWithSpaces(formatBytes(total_unoptimized_size));
     vue_data["image_compression"] = imageCompression(total_optimized_size, total_unoptimized_size) + '%';
+    console.log("total optimised: ", vue_data["total_size_optimized"]);
+    console.log("total unoptimised: ", vue_data["total_size_unoptimized"]);
+    console.log("compression: ", vue_data["image_compression"]);
 
 }
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -76,7 +76,7 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 function summarizeImagesModel(images_summary_input) {
     let total_unoptimized_size = 0.0;
     for (let im_url of Object.getOwnPropertyNames(images_summary_input.unoptimized)) {
-        total_unoptimized_size += images_summary_input.unoptimized[im_url];
+        total_unoptimized_size += images_summary_input.unoptimized[im_url].transfer_size;
     }
 
     let total_optimized_size = 0.0;

--- a/js/popup.js
+++ b/js/popup.js
@@ -37,9 +37,9 @@ let vue_data = {
 
 
 browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-    //console.log(request);
+    console.log(request);
     if (sender.tab && sender.tab.active) {
-        console.log("Message from active tab");
+        // console.log("Message from active tab");
         localStorage.setItem('clog', JSON.stringify(request));
         if (request.active === false) {
             vue_data["Active"] = false;
@@ -80,9 +80,9 @@ function summarizeImagesModel(images_summary_input) {
 
     let total_optimized_size = 0.0;
     for (let im_url of Object.getOwnPropertyNames(images_summary_input.optimized)) {
-        console.log("From the total optimised function ")
-        console.log(im_url)
-        console.log(images_summary_input.optimized[im_url].transfer_size)
+        // console.log("From the total optimised function ")
+        // console.log(im_url)
+        // console.log(images_summary_input.optimized[im_url].transfer_size)
         total_optimized_size += images_summary_input.optimized[im_url].transfer_size;
     }
 
@@ -147,7 +147,7 @@ window.vue_body_app = new Vue({
                         return browser.tabs.sendMessage(tabs[0].id, { newShim: to_what });
                     })
                 .then((response) => {
-                    console.log(response);
+                    // console.log(response);
                 });
             this.saveData();
         },
@@ -168,7 +168,7 @@ window.vue_body_app = new Vue({
 
     watch: {
         shim: function (new_shim, old_shim) {
-            console.log("Shim changed to ", new_shim);
+            // console.log("Shim changed to ", new_shim);
             this.changeShim(new_shim);
         }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-   "name": "ShimmerCat Image Extension",
-   "version": "0.2",
+   "name": "DEV ShimmerCat Image Extension DEV",
+   "version": "0.3",
    "description": "In-page statistics about image optimization",
    "manifest_version": 2,
 

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,7 @@
         "matches": ["https://*/*"],
         "js": [
           "js/lodash.js",
-		   "js/find_domain_name.js",
+		      "js/find_domain_name.js",
           "js/browser_polyfill.js",
           "content-js/state.js"
         ],

--- a/popup.html
+++ b/popup.html
@@ -31,17 +31,17 @@
         </header>
     </div>
     <div id="app-root">
-        <div v-if="ServiceWorker==true&&SplashScreen==false" class="Message">
+        <!-- <div v-if="ServiceWorker==true&&SplashScreen==false" class="Message">
             <label class="ErrorMessage">
                 This website uses ShimmerCat Service Worker.
             </label>
-        </div>
+        </div> -->
         <div v-if="!Active && !ServiceWorker&&SplashScreen==false" class="Message">
             <label class="ErrorMessage">
                 This Website is not served by ShimmerCat.
             </label>
         </div>
-        <div class="radiobutton-area" v-if="Active && !ServiceWorker &&SplashScreen==false">
+        <div class="radiobutton-area" v-if="Active &&SplashScreen==false">
             <p class="p-position">Show</p>
             <div class="r-position t-1">
                 <input class="shim-radio" type="radio" id="optimized" name="shim-type" value="optimized" v-model="shim">

--- a/popup.html
+++ b/popup.html
@@ -78,6 +78,9 @@
                             <li>Pulsating images: Image is being pro-
                                 <br>cessed
                             </li>
+                            <li>Blue images: Image has been pro-
+                                <br>cessed by the ServiceWorker
+                            </li>
                         </ul>
                     </div>
                     <div class="label-align">

--- a/popup.html
+++ b/popup.html
@@ -85,6 +85,7 @@
                             <span> Image Compression:</span>
                         </div>
                         <div class="amount div-2">
+                            <!-- <span v-if="image_compression < 0">0%</span> -->
                             <span>{{image_compression}}</span>
                         </div>
                         <div class="sublabel div-3">
@@ -102,7 +103,18 @@
                     </div>
                 </div>
                 <div class="ImagesCount">
-                    <label>Images Detected: {{imagesCount}}</label>
+                    <label><span class="bold">Images Detected:</span> {{imagesCount}}</label>
+                </div>
+                <div class="filetypes-count-div">
+                    <span class="bold">Filetypes:</span>
+                    <div v-for="(value, name) in filetypes">
+                        - {{ name }}: {{ value }}
+                      </div>
+                    <!-- <ul v-if="Object.keys(filetypes).length !== 0" id="example-1">
+                        <li v-for="(value, name) in filetypes">
+                            {{ name }}: {{ value }}
+                        </li>
+                      </ul> -->
                 </div>
                 <div class="exportcsvdiv">
                     <a href="download.html" class="btn btn-top">Export to CSV</a>


### PR DESCRIPTION
1. Support for serviceWorker-enabled sites added
2. Dual support for sites using original optimisation detection as well as serviceWorker-supported domains
3. CSV output fixed - columns were not matched before and each image's respective optimised, original size was jumbled
4. Chunked image response functionality added - before chunked images were not supported as there was no way to gather filesize as Content-Length header was missing
5. Brief documentation added
6. Cleaned code up - a lot of console.logs removed 